### PR TITLE
Add a launch file to launch chatter apps together

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,4 +52,7 @@ use_repo(
     rules_ros2_non_module_deps,
     "ros2_common_interfaces",
     "ros2_rclpy",
+    # ros2cli and ros2_launch_ros are required to run a ros2_launch target
+    "ros2cli",
+    "ros2_launch_ros",
 )

--- a/src/examples/BUILD
+++ b/src/examples/BUILD
@@ -1,3 +1,4 @@
+load("@com_github_mvukov_rules_ros2//ros2:launch.bzl", "ros2_launch")
 load("@robotpy_bazel_pip_deps//:requirements.bzl", "requirement")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary")
@@ -35,5 +36,14 @@ py_binary(
     deps = [
         "@ros2_common_interfaces//:py_std_msgs",
         "@ros2_rclpy//:rclpy",
+    ],
+)
+
+ros2_launch(
+    name = "chatter",
+    launch_file = "chatter.launch.py",
+    nodes = [
+        ":talker",
+        ":listener",
     ],
 )

--- a/src/examples/chatter.launch.py
+++ b/src/examples/chatter.launch.py
@@ -1,0 +1,14 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            executable = 'src/examples/talker',
+            name = 'talker'
+        ),
+        Node(
+            executable = 'src/examples/listener',
+            name = 'listener'
+        ),
+    ])


### PR DESCRIPTION
Ros 2's launch system lets us specify what programs to run, where to run them, what arguments to pass to them, etc. It is also responsible monitoring the state of the processes launched, and reporting and/or reacting to changes in the state of those processes.

Add a simple launch file that just launches our `talker` and `listener` applications, and a Bazel target for it. This lets us spin up both nodes with the command:
```
bazel run -c opt //src/examples:chatter
```