### PR TITLE
Add an integration test for talker

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,4 +55,6 @@ use_repo(
     # ros2cli and ros2_launch_ros are required to run a ros2_launch target
     "ros2cli",
     "ros2_launch_ros",
+    # ros2launch is required to test a ros2_test target
+    "ros2_launch",
 )

--- a/src/examples/BUILD
+++ b/src/examples/BUILD
@@ -1,4 +1,5 @@
 load("@com_github_mvukov_rules_ros2//ros2:launch.bzl", "ros2_launch")
+load("@com_github_mvukov_rules_ros2//ros2:test.bzl", "ros2_test")
 load("@robotpy_bazel_pip_deps//:requirements.bzl", "requirement")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary")
@@ -45,5 +46,17 @@ ros2_launch(
     nodes = [
         ":talker",
         ":listener",
+    ],
+)
+
+ros2_test(
+    name = "talker_test",
+    size = "small",
+    launch_file = "talker_test.py",
+    nodes = [
+        ":talker",
+    ],
+    deps = [
+        "@ros2_common_interfaces//:py_std_msgs"
     ],
 )

--- a/src/examples/listener.py
+++ b/src/examples/listener.py
@@ -8,7 +8,7 @@ class Listener(Node):
         self.create_subscription(String, 'chatter', self.listener_callback, 10)
 
     def listener_callback(self, msg):
-        self.get_logger().debug(f'I heard {msg.data}')
+        self.get_logger().info(f'I heard {msg.data}')
 
 def main():
     rclpy.init()
@@ -21,7 +21,7 @@ def main():
         listener.destroy_node()
         # TODO: Uncomment the following line once the double shutdown bug is fixed.
         # https://github.com/ros2/rclpy/issues/1081
-        rclpy.shutdown()
+        # rclpy.shutdown()
 
 if __name__ == '__main__':
     main()

--- a/src/examples/listener.py
+++ b/src/examples/listener.py
@@ -8,7 +8,7 @@ class Listener(Node):
         self.create_subscription(String, 'chatter', self.listener_callback, 10)
 
     def listener_callback(self, msg):
-        self.get_logger().info(f'I heard {msg.data}')
+        self.get_logger().debug(f'I heard {msg.data}')
 
 def main():
     rclpy.init()
@@ -19,6 +19,8 @@ def main():
         pass
     finally:
         listener.destroy_node()
+        # TODO: Uncomment the following line once the double shutdown bug is fixed.
+        # https://github.com/ros2/rclpy/issues/1081
         rclpy.shutdown()
 
 if __name__ == '__main__':

--- a/src/examples/talker.py
+++ b/src/examples/talker.py
@@ -15,7 +15,7 @@ class Talker(Node):
         msg = String()
         msg.data = f'Hello, world: {self.i}'
         self.publisher.publish(msg)
-        self.get_logger().debug(f'Publishing: {msg.data}')
+        self.get_logger().info(f'Publishing: {msg.data}')
         self.i += 1
 
 def main():

--- a/src/examples/talker.py
+++ b/src/examples/talker.py
@@ -5,14 +5,18 @@ from std_msgs.msg import String
 class Talker(Node):
     def __init__(self):
         super().__init__('talker')
+        self.declare_parameter('timer_period_sec', 1.0)
+        self.timer_period_sec = self.get_parameter('timer_period_sec')
         self.publisher = self.create_publisher(String, 'chatter', 10)
-        self.timer = self.create_timer(1.0, self.timer_callback)
+        self.timer = self.create_timer(self.timer_period_sec.value, self.timer_callback)
+        self.i = 0
 
     def timer_callback(self):
         msg = String()
-        msg.data = 'Hello, world!'
+        msg.data = f'Hello, world: {self.i}'
         self.publisher.publish(msg)
-        self.get_logger().info(f'Publishing: {msg.data}')
+        self.get_logger().debug(f'Publishing: {msg.data}')
+        self.i += 1
 
 def main():
     rclpy.init()
@@ -23,7 +27,9 @@ def main():
         pass
     finally:
         talker.destroy_node()
-        rclpy.shutdown()
+        # TODO: Uncomment the following line once the double shutdown bug is fixed.
+        # https://github.com/ros2/rclpy/issues/1081
+        # rclpy.shutdown()
 
 if __name__ == '__main__':
     main()

--- a/src/examples/talker_test.py
+++ b/src/examples/talker_test.py
@@ -63,6 +63,19 @@ class TalkerTest(unittest.TestCase):
             end_time = time.time() + 1
             while time.time() < end_time:
                 rclpy.spin_once(self.node, timeout_sec=0.02)
-            self.assertGreater(len(messages_rx), 100)
+            self.assertGreaterEqual(len(messages_rx), 100)
+        finally:
+            self.node.destroy_subscription(subscriber)
+
+    def test_talker_message_increment(self, proc_output):
+        """Tests that the talker increments the value in the message by 1 each time."""
+        values_rx = []
+        subscriber = self.node.create_subscription(std_msgs.msg.String, 'chatter', lambda message: values_rx.append(int(message.data.split(': ')[1])) if message.data.startswith('Hello, world: ') and message.data.split(': ')[1].isdigit() else None, 10)
+
+        try:
+            end_time = time.time() + 2
+            while len(values_rx) < 100:
+                rclpy.spin_once(self.node, timeout_sec=0.02)
+            self.assertTrue(all(values_rx[i] == values_rx[i-1] + 1 for i in range(1, len(values_rx))))
         finally:
             self.node.destroy_subscription(subscriber)

--- a/src/examples/talker_test.py
+++ b/src/examples/talker_test.py
@@ -18,7 +18,12 @@ def generate_test_description():
                 {
                     'timer_period_sec': 0.01
                 }
-            ]
+            ],
+            arguments = [
+                "--ros-args",
+                "--log-level",
+                "warn"
+            ],
         ),
         # The talker node seems to take ~half a second to start publishing. Since our
         # test cases expect talker to be in steady state (already publishing

--- a/src/examples/talker_test.py
+++ b/src/examples/talker_test.py
@@ -1,0 +1,63 @@
+import time
+import unittest
+
+import rclpy
+import launch_testing.markers
+import std_msgs.msg
+from launch import LaunchDescription
+from launch.actions import TimerAction
+from launch_ros.actions import Node
+from launch_testing.actions import ReadyToTest
+
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    return LaunchDescription([
+        Node(
+            executable = 'src/examples/talker',
+            parameters = [
+                {
+                    'timer_period_sec': 0.01
+                }
+            ]
+        ),
+        # The talker node seems to take ~half a second to start publishing. Since our
+        # test cases expect talker to be in steady state (already publishing
+        # periodically), have the test node launch a full second after the talker to be
+        # on the safe side.
+        # TODO: Is there a more deterministic way to do this?
+        TimerAction(
+            period = 1.0,
+            actions = [
+                ReadyToTest()
+            ]
+        ),
+    ])
+
+class TalkerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('talker_test')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_talker_publish_frequency(self, proc_output):
+        """Tests that the talker publishes at the frequency specified via the parameter."""
+        messages_rx = []
+        subscriber = self.node.create_subscription(std_msgs.msg.String, 'chatter', lambda message: messages_rx.append(message), 10)
+
+        try:
+            # Run for 1 second and verify that we got ~100 messages (once every 10ms).
+            end_time = time.time() + 1
+            while time.time() < end_time:
+                rclpy.spin_once(self.node, timeout_sec=0.02)
+            self.assertGreater(len(messages_rx), 100)
+        finally:
+            self.node.destroy_subscription(subscriber)


### PR DESCRIPTION
This type of test spins up any nodes that you specify and a test node for each test case.

Change talker's publish rate to use a parameter. Set the parameter to a specific value for the test, and verify that it indeed publishes at that frequency.