### PR TITLE
Parse the pip dependencies for Python 3.11

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,6 +31,13 @@ uv.configure(version = "0.6.14")
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "robotpy_bazel_pip_deps",
+    python_version = "3.11",
+    requirements_lock = "//:requirements_lock.txt",
+    experimental_index_url = "https://pypi.org/simple",
+    download_only = True,
+)
+pip.parse(
+    hub_name = "robotpy_bazel_pip_deps",
     python_version = "3.13",
     requirements_lock = "//:requirements_lock.txt",
     experimental_index_url = "https://pypi.org/simple",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -4,4 +4,6 @@ py_binary(
     name = "python_version",
     srcs = ["python_version.py"],
     main = "python_version.py",
+    # Change this to the version you want to test. See MODULE.bazel for supported versions.
+    python_version = "3.13",
 )


### PR DESCRIPTION
PR #9 pulled in Python 3.11, but did not parse the requirements lock file to fetch pip dependencies for that version. Fix that here.